### PR TITLE
Power off Soundtouch.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,8 +109,8 @@ SoundTouchAccessory.prototype._setOn = function(on, callback) {
             });
         });
     } else {
-        this.device.stop(function() {
-            accessory.log('Stopping...');
+        this.device.powerOff(function() {
+            accessory.log('Powering Off...');
             callback(null);
         });
     }


### PR DESCRIPTION
Turn off Soundtouch when switch set to off instead of stopping the music.